### PR TITLE
[THORN-2495] add health checks to the cache server deployment

### DIFF
--- a/greeting-service/.openshiftio/service.cache.yml
+++ b/greeting-service/.openshiftio/service.cache.yml
@@ -21,7 +21,19 @@ items:
       spec:
         containers:
         - name: cache-server
-          image: registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:1.0
+          image: registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:1.3
+          livenessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/datagrid/bin/livenessProbe.sh"
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/datagrid/bin/readinessProbe.sh"
           env:
           - name: DEFAULT_CACHE_EXPIRATION_LIFESPAN
             value: "10000"

--- a/service.cache.yml
+++ b/service.cache.yml
@@ -21,7 +21,19 @@ items:
       spec:
         containers:
         - name: cache-server
-          image: registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:1.0
+          image: registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:1.3
+          livenessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/datagrid/bin/livenessProbe.sh"
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/datagrid/bin/readinessProbe.sh"
           env:
           - name: DEFAULT_CACHE_EXPIRATION_LIFESPAN
             value: "10000"

--- a/tests/src/test/resources/test-cache.yml
+++ b/tests/src/test/resources/test-cache.yml
@@ -21,7 +21,19 @@ items:
       spec:
         containers:
         - name: cache-server
-          image: registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:1.0
+          image: registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:1.3
+          livenessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/datagrid/bin/livenessProbe.sh"
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/datagrid/bin/readinessProbe.sh"
           env:
           - name: DEFAULT_CACHE_EXPIRATION_LIFESPAN
             value: "10000"


### PR DESCRIPTION
Before this commit, tests used to fail like this:

```
[ERROR] cacheShouldExpire(io.thorntail.example.OpenshiftIT)  Time elapsed: 3.265 s  <<< FAILURE!
java.lang.AssertionError:
1 expectation failed.
Expected status code <204> but was <500>.

        at io.thorntail.example.OpenshiftIT.clearCache(OpenshiftIT.java:137)
        at io.thorntail.example.OpenshiftIT.setup(OpenshiftIT.java:53)
```

This only happened when the DataGrid image [1] was not available
in the cluster beforehand and had to be downloaded on the fly.
In such situation, the last deployment that becomes ready
is the DataGrid deployment, because the testing applications are
long started. When the cache server is marked ready, the test
immediately starts, and the first thing it does is invoking the
"clear cache" API. That tries to contact the cache server, but
that isn't fully started yed, even though it's "ready", and so
the API invocation fails. The ultimate cause is that the cache
server deployment doesn't define health checks.

This could be worked around by making the `clearCache` method loop
until the "clear cache" API invocation succeeds. However, proper
solution is to add health checks. This commit does exactly that,
as recommended by the DataGrid documentation [2].

[1] `registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift`
[2] https://access.redhat.com/documentation/en-us/red_hat_data_grid/7.3/html/red_hat_data_grid_for_openshift/os_reference#probes)